### PR TITLE
Fix the printing of help text by argument parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,3 @@ Every cosmetic attributes are customizable through command line options, except 
 To use, invoque matrix_code_rain.py in a terminal.
 If you experience stuttering, try decreasing the number of frames per second with the -f option.
 
-### known bugs
-
-on mac os x and python 3.4.3, the argument parser can not display the help (not tested on other OS).

--- a/argument_parsing.py
+++ b/argument_parsing.py
@@ -24,7 +24,7 @@ def getArgs():
         parser.add_argument('-d', '--density', nargs = '?', type = float, help= 'a decimal number representing how frequently drops will appear on the screen (arbitrary value, base value 0.07)')
         parser.add_argument('-s', '--speed', nargs = 2, type = float, help = 'two decimal or integers decribing the range of possible speeds for the drops to fall at (values expressed in lines per second, base values: 15 35)')
         parser.add_argument('-p', '--persistence', nargs = 2, type = float, help = 'two decimal or integers decribing the range of possible duration that the drop can pour before falling down the screen (values expressed in seconds, base values: 0.5 5)')
-        parser.add_argument('-n', '--notontop', nargs = '?', type =  float, help = 'a decimal number describing the chance for a drop not to appear on top of the screen, base value: 0.33 meaning 33% chance')
+        parser.add_argument('-n', '--notontop', nargs = '?', type =  float, help = 'a decimal number describing the chance for a drop not to appear on top of the screen, base value: 0.33 meaning 33%% chance')
         parser.add_argument('-m', '--middlerange',  nargs = 2, type =  float, help = 'two decimal or integers decribing the proportion of the screen in which the drops that will not appear on top of the screen will appear in (base value: 0.25 0.75, meaning between 1/4 and 3/4 of the screen)')
 
         args = parser.parse_args()


### PR DESCRIPTION
The bug currently mentioned in the [README](https://github.com/arozec/matrix-code-rain/commit/6ae7a3c5362ef4768bb8589dfe0fa7392e271710#diff-04c6e90faac2675aa89e2176d2eec7d8R10) is caused by [an unescaped percent sign](https://github.com/arozec/matrix-code-rain/blob/master/argument_parsing.py#L27).

This PR fixes the bug by escaping the percent sign, and removes the part in the README mentioning it.
